### PR TITLE
vsock: use ioctl constant from golang.org/x/sys/unix

### DIFF
--- a/ioctl_linux.go
+++ b/ioctl_linux.go
@@ -9,12 +9,6 @@ import (
 )
 
 const (
-	// ioctlGetLocalCID is an ioctl value that retrieves the local context ID
-	// from /dev/vsock.
-	// TODO(mdlayher): this is probably linux/amd64 specific, but I'm unsure
-	// how to make it portable across architectures.
-	ioctlGetLocalCID = 0x7b9
-
 	// devVsock is the location of /dev/vsock.  It is exposed on both the
 	// hypervisor and on virtual machines.
 	devVsock = "/dev/vsock"
@@ -39,7 +33,7 @@ func localContextID(fs fs, cid *uint32) error {
 	defer f.Close()
 
 	// Retrieve the context ID of this machine from /dev/vsock.
-	return fs.Ioctl(f.Fd(), ioctlGetLocalCID, uintptr(unsafe.Pointer(cid)))
+	return fs.Ioctl(f.Fd(), unix.IOCTL_VM_SOCKETS_GET_LOCAL_CID, uintptr(unsafe.Pointer(cid)))
 }
 
 // A sysFS is the system call implementation of fs.

--- a/ioctl_linux_test.go
+++ b/ioctl_linux_test.go
@@ -5,6 +5,8 @@ package vsock
 import (
 	"os"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 func Test_localContextIDGuest(t *testing.T) {
@@ -31,7 +33,7 @@ func Test_localContextIDGuest(t *testing.T) {
 				want, got)
 		}
 
-		if want, got := ioctlGetLocalCID, request; want != got {
+		if want, got := unix.IOCTL_VM_SOCKETS_GET_LOCAL_CID, request; want != got {
 			t.Fatalf("unexpected request number for ioctl:\n- want: %x\n-  got: %x",
 				want, got)
 		}


### PR DESCRIPTION
Now that https://golang.org/cl/76193 added it, use the portable
definition of IOCTL_VM_SOCKETS_GET_LOCAL_CID.