### PR TITLE
README: fix guest driver name

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Before using VM sockets, following modules must be removed on hypervisor:
 Once removed, `vhost_vsock` module needs to be enabled on hypervisor:
   - `modprobe vhost_vsock`
 
-On VM, you have to enable `vmw_vsock_vmci_transport` module.
+On VM, you have to enable `vmw_vsock_virtio_transport` module.  This module should automatically load during boot when the vsock device is detected.
 
 To utilize VM sockets, VM needs to be powered on with following `-device` flag:
   - `-device vhost-vsock-pci,id=vhost-vsock-pci0,guest-cid=3`


### PR DESCRIPTION
The virtio-vsock guest driver is vmw_vsock_virtio_transport.ko.  It's
important to use this kernel module and not the
vmw_vsock_vmci_transport.ko VMware guest driver.  In practice the
correct driver is automatically loaded but it's worth clarifying the
documentation.