### PR TITLE
vsock/conn: don't use struct embedding

### DIFF
--- a/conn_linux_test.go
+++ b/conn_linux_test.go
@@ -101,7 +101,7 @@ func Test_dialStreamLinuxFull(t *testing.T) {
 			want, got)
 	}
 
-	if want, got := localFD, c.File.Fd(); want != got {
+	if want, got := localFD, c.file.Fd(); want != got {
 		t.Fatalf("unexpected conn file descriptor:\n- want: %d\n-  got: %d",
 			want, got)
 	}

--- a/listener_linux.go
+++ b/listener_linux.go
@@ -36,7 +36,7 @@ func (l *listener) Accept() (net.Conn, error) {
 	}
 
 	return &conn{
-		File:       cfd.NewFile(l.addr.fileName()),
+		file:       cfd.NewFile(l.addr.fileName()),
 		localAddr:  l.addr,
 		remoteAddr: remoteAddr,
 	}, nil

--- a/listener_linux_test.go
+++ b/listener_linux_test.go
@@ -181,7 +181,7 @@ func Test_listenerAccept(t *testing.T) {
 			want, got)
 	}
 
-	if want, got := connFD, c.File.Fd(); want != got {
+	if want, got := connFD, c.file.Fd(); want != got {
 		t.Fatalf("unexpected conn file descriptor:\n- want: %d\n-  got: %d",
 			want, got)
 	}


### PR DESCRIPTION
No reason to do it and only possibly a source of bugs.