### PR TITLE
vsock: enable timeouts also on listener connections

### DIFF
--- a/listener_linux.go
+++ b/listener_linux.go
@@ -35,6 +35,12 @@ func (l *listener) Accept() (net.Conn, error) {
 		Port:      savm.Port,
 	}
 
+	// Enable integration with runtime network poller for timeout support
+	// in Go 1.11+.
+	if err := cfd.SetNonblock(true); err != nil {
+		return nil, err
+	}
+
 	return &conn{
 		file:       cfd.NewFile(l.addr.fileName()),
 		localAddr:  l.addr,


### PR DESCRIPTION
conn.SetDeadline() seems to work only on client connections. Trying to set a deadline on a listener connection always fails with "file type does not support deadline"
It seems that setting the FD created by Accept4() into non blocking mode solves the issue.
Thanks.