### PR TITLE
vsock: set listener fd to blocking mode

### DIFF
--- a/listener_linux.go
+++ b/listener_linux.go
@@ -83,7 +83,7 @@ func listenStreamLinux(lfd fd, cid, port uint32) (net.Listener, error) {
 		Port: port,
 	}
 
-	if err := lfd.SetNonblock(true); err != nil {
+	if err := lfd.SetNonblock(false); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Currently vscp application does not work since listener fd is set nonblocking mode. Thus l.Accept() returns as soon as it does not find a client. But in reality running a client might take some time and it should wait for client to come up and send a connect request.