### PR TITLE
 vsock: initial Go 1.12 runtime network poller support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
   - 1.x
+  - 1.11.x
 os:
   - linux
 sudo: required

--- a/README.md
+++ b/README.md
@@ -6,14 +6,32 @@ communication between a hypervisor and its virtual machines.  MIT Licensed.
 For more information about VM sockets, check out my blog about
 [Linux VM sockets in Go](https://medium.com/@mdlayher/linux-vm-sockets-in-go-ea11768e9e67).
 
+## Go version support
+
+This package supports varying levels of functionality depending on the version
+of Go used during compilation. The `net.Listener` and `net.Conn` types produced
+by this package are backed by non-blocking I/O, in order to integrate with Go's
+runtime network poller in newer versions of Go.
+
+- **Go 1.12.x+ (recommended):**
+  - `net.Listener`:
+    - `Accept` blocks until a connection is received
+    - `Close` can interrupt `Accept` and make it return a permanent error
+  - `net.Conn`: full timeout support via `SetDeadline` family of methods
+- Go 1.11.x **(not recommended)**:
+  - `net.Listener`:
+    - `Accept` is **non-blocking** and should be called in a loop, checking for
+      `net.Error.Temporary() == true` and sleeping for a short period to avoid
+      wasteful, spinning CPU cycles
+    - `Close` makes `Accept` return a permanent error on the next
+      loop iteration
+  - `net.Conn`: full timeout support via `SetDeadline` family of methods
+- Go 1.10.x or below: **not supported**
+
 ## Stability
 
 At this time, package `vsock` is in a pre-v1.0.0 state. Changes are being made
 which may impact the exported API of this package and others in its ecosystem.
-
-The general policy of this package is to only support the latest, stable version
-of Go. Compatibility shims may be added for prior versions of Go on an as-needed
-basis. If you would like to raise a concern, please [file an issue](https://github.com/mdlayher/vsock/issues/new).
 
 **If you depend on this package in your applications, please vendor it or use Go
 modules when building your application.**

--- a/conn_linux.go
+++ b/conn_linux.go
@@ -31,7 +31,7 @@ func (c *conn) Close() error                       { return c.fd.Close() }
 // newConn creates a conn using an connFD, immediately setting the connFD to
 // non-blocking mode for use with the runtime network poller.
 func newConn(cfd connFD, local, remote *Addr) (*conn, error) {
-	if err := cfd.SetNonblocking("vsock " + local.String()); err != nil {
+	if err := cfd.SetNonblocking(local.fileName()); err != nil {
 		return nil, err
 	}
 

--- a/fd_linux.go
+++ b/fd_linux.go
@@ -1,45 +1,223 @@
 package vsock
 
 import (
+	"io"
 	"os"
+	"syscall"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
 
-// A fd is an interface for a file descriptor, used to perform system
-// calls or swap them out for tests.
-type fd interface {
-	Accept4(flags int) (fd, unix.Sockaddr, error)
+type listenFD interface {
+	io.Closer
+	Accept4(flags int) (connFD, unix.Sockaddr, error)
 	Bind(sa unix.Sockaddr) error
-	Close() error
-	Connect(sa unix.Sockaddr) error
-	Getsockname() (unix.Sockaddr, error)
 	Listen(n int) error
-	NewFile(name string) *os.File
-	SetNonblock(nonblocking bool) error
+	Getsockname() (unix.Sockaddr, error)
 }
 
-var _ fd = &sysFD{}
-
-// sysFD is the system call implementation of fd.
-type sysFD struct {
-	fd int
+type sysListenFD struct {
+	f *os.File
 }
 
-func (fd *sysFD) Accept4(flags int) (fd, unix.Sockaddr, error) {
-	// Returns a regular file descriptor, must be wrapped in another
-	// sysFD for it to work properly.
-	nfd, sa, err := unix.Accept4(fd.fd, flags)
+func newListenFD() (*sysListenFD, error) {
+	fd, err := unix.Socket(unix.AF_VSOCK, unix.SOCK_STREAM, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := unix.SetNonblock(fd, true); err != nil {
+		return nil, err
+	}
+
+	return &sysListenFD{
+		f: os.NewFile(uintptr(fd), "vsock-listen"),
+	}, nil
+}
+
+func (lfd *sysListenFD) Accept4(flags int) (connFD, unix.Sockaddr, error) {
+	var (
+		nfd int
+		sa  unix.Sockaddr
+		err error
+	)
+
+	doErr := fdread(lfd.f, func(fd int) bool {
+		// Returns a regular file descriptor, must be wrapped in another
+		// sysConnFD for it to work properly.
+		nfd, sa, err = unix.Accept4(fd, flags)
+
+		// When the socket is in non-blocking mode, we might see
+		// EAGAIN and end up here. In that case, return false to
+		// let the poller wait for readiness. See the source code
+		// for internal/poll.FD.RawRead for more details.
+		//
+		// If the socket is in blocking mode, EAGAIN should never occur.
+		return err != syscall.EAGAIN
+	})
+	if doErr != nil {
+		return nil, nil, doErr
+	}
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return &sysFD{fd: nfd}, sa, nil
+	cfd, err := newConnFD(nfd)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cfd, sa, nil
 }
-func (fd *sysFD) Bind(sa unix.Sockaddr) error         { return unix.Bind(fd.fd, sa) }
-func (fd *sysFD) Close() error                        { return unix.Close(fd.fd) }
-func (fd *sysFD) Connect(sa unix.Sockaddr) error      { return unix.Connect(fd.fd, sa) }
-func (fd *sysFD) Getsockname() (unix.Sockaddr, error) { return unix.Getsockname(fd.fd) }
-func (fd *sysFD) Listen(n int) error                  { return unix.Listen(fd.fd, n) }
-func (fd *sysFD) NewFile(name string) *os.File        { return os.NewFile(uintptr(fd.fd), name) }
-func (fd *sysFD) SetNonblock(nonblocking bool) error  { return unix.SetNonblock(fd.fd, nonblocking) }
+
+func (lfd *sysListenFD) Bind(sa unix.Sockaddr) error {
+	var err error
+	doErr := fdcontrol(lfd.f, func(fd int) {
+		err = unix.Bind(fd, sa)
+	})
+	if doErr != nil {
+		return doErr
+	}
+
+	return err
+}
+
+func (lfd *sysListenFD) Close() error {
+	var err error
+	doErr := fdcontrol(lfd.f, func(fd int) {
+		err = unix.Close(fd)
+	})
+	if doErr != nil {
+		return doErr
+	}
+
+	_ = lfd.f.Close()
+	return err
+}
+
+func (lfd *sysListenFD) Getsockname() (unix.Sockaddr, error) {
+	var (
+		sa  unix.Sockaddr
+		err error
+	)
+
+	doErr := fdcontrol(lfd.f, func(fd int) {
+		sa, err = unix.Getsockname(fd)
+	})
+	if doErr != nil {
+		return nil, doErr
+	}
+
+	return sa, err
+}
+
+func (lfd *sysListenFD) Listen(n int) error {
+	var err error
+	doErr := fdcontrol(lfd.f, func(fd int) {
+		err = unix.Listen(fd, n)
+	})
+	if doErr != nil {
+		return doErr
+	}
+
+	return err
+}
+
+// A fd is an interface for a file descriptor, used to perform system
+// calls or swap them out for tests.
+type connFD interface {
+	io.ReadWriteCloser
+	Getsockname() (unix.Sockaddr, error)
+	SetDeadline(t time.Time) error
+	SetReadDeadline(t time.Time) error
+	SetWriteDeadline(t time.Time) error
+}
+
+var _ connFD = &sysConnFD{}
+
+func newConnFD(fd int) (*sysConnFD, error) {
+	if err := unix.SetNonblock(fd, true); err != nil {
+		_ = unix.Close(fd)
+		return nil, err
+	}
+
+	return &sysConnFD{
+		f: os.NewFile(uintptr(fd), "vsock"),
+	}, nil
+}
+
+// sysConnFD is the system call implementation of fd.
+type sysConnFD struct {
+	f *os.File
+}
+
+func (cfd *sysConnFD) Getsockname() (unix.Sockaddr, error) {
+	var (
+		sa  unix.Sockaddr
+		err error
+	)
+
+	doErr := fdcontrol(cfd.f, func(fd int) {
+		sa, err = unix.Getsockname(fd)
+	})
+	if doErr != nil {
+		return nil, doErr
+	}
+
+	return sa, err
+}
+
+func (cfd *sysConnFD) File() *os.File {
+	return cfd.f
+}
+
+func (cfd *sysConnFD) Close() error {
+	var err error
+	doErr := fdcontrol(cfd.f, func(fd int) {
+		err = unix.Close(fd)
+	})
+	if doErr != nil {
+		return doErr
+	}
+
+	_ = cfd.f.Close()
+
+	return err
+}
+
+func (cfd *sysConnFD) Read(b []byte) (int, error) {
+	n, err := cfd.f.Read(b)
+	if err != nil {
+		if perr, ok := err.(*os.PathError); ok && perr.Err == unix.ENOTCONN {
+			return n, io.EOF
+		}
+	}
+
+	return n, err
+}
+
+func (cfd *sysConnFD) Write(b []byte) (int, error)        { return cfd.f.Write(b) }
+func (cfd *sysConnFD) SetDeadline(t time.Time) error      { return cfd.f.SetDeadline(t) }
+func (cfd *sysConnFD) SetReadDeadline(t time.Time) error  { return cfd.f.SetReadDeadline(t) }
+func (cfd *sysConnFD) SetWriteDeadline(t time.Time) error { return cfd.f.SetWriteDeadline(t) }
+
+func fdread(fd *os.File, f func(int) bool) error {
+	rc, err := fd.SyscallConn()
+	if err != nil {
+		return err
+	}
+	return rc.Read(func(sysConnFD uintptr) bool {
+		return f(int(sysConnFD))
+	})
+}
+
+func fdcontrol(fd *os.File, f func(int)) error {
+	rc, err := fd.SyscallConn()
+	if err != nil {
+		return err
+	}
+	return rc.Control(func(sysConnFD uintptr) {
+		f(int(sysConnFD))
+	})
+}

--- a/fd_linux.go
+++ b/fd_linux.go
@@ -135,8 +135,7 @@ func (lfd *sysListenFD) check() {
 	}
 }
 
-// A fd is an interface for a file descriptor, used to perform system
-// calls or swap them out for tests.
+// A connFD is a type that wraps a file descriptor used to implement net.Conn.
 type connFD interface {
 	io.ReadWriteCloser
 	Connect(sa unix.Sockaddr) error
@@ -149,6 +148,7 @@ type connFD interface {
 
 var _ connFD = &sysConnFD{}
 
+// newConnFD creates a sysConnFD in its default blocking mode.
 func newConnFD() (*sysConnFD, error) {
 	fd, err := unix.Socket(unix.AF_VSOCK, unix.SOCK_STREAM, 0)
 	if err != nil {
@@ -160,7 +160,7 @@ func newConnFD() (*sysConnFD, error) {
 	}, nil
 }
 
-// sysConnFD is the system call implementation of fd.
+// A sysConnFD is the system call implementation of connFD.
 type sysConnFD struct {
 	// These fields should never be non-zero at the same time.
 	fd int      // Used in blocking mode.

--- a/fd_linux.go
+++ b/fd_linux.go
@@ -110,6 +110,12 @@ func (lfd *sysListenFD) Accept4(flags int) (connFD, unix.Sockaddr, error) {
 func (lfd *sysListenFD) Close() error {
 	lfd.check()
 
+	// It is possible that Close will be called before a transition to
+	// non-blocking mode in Accept.
+	if lfd.f == nil {
+		return unix.Close(lfd.fd)
+	}
+
 	var err error
 	doErr := fdcontrol(lfd.f, func(fd int) {
 		err = unix.Close(fd)

--- a/fd_linux_gteq_1.12.go
+++ b/fd_linux_gteq_1.12.go
@@ -1,0 +1,46 @@
+//+build go1.12,linux
+
+package vsock
+
+import "golang.org/x/sys/unix"
+
+func (lfd *sysListenFD) accept4(flags int) (int, unix.Sockaddr, error) {
+	// In Go 1.12+, we make use of runtime network poller integration to allow
+	// net.Listener.Accept to be unblocked by a call to net.Listener.Close.
+	rc, err := lfd.f.SyscallConn()
+	if err != nil {
+		return 0, nil, err
+	}
+
+	var (
+		newFD int
+		sa    unix.Sockaddr
+	)
+
+	doErr := rc.Read(func(fd uintptr) bool {
+		newFD, sa, err = unix.Accept4(int(fd), flags)
+
+		switch err {
+		case unix.EAGAIN, unix.ECONNABORTED:
+			// Return false to let the poller wait for readiness. See the
+			// source code for internal/poll.FD.RawRead for more details.
+			//
+			// When the socket is in non-blocking mode, we might see EAGAIN if
+			// the socket is not ready for reading.
+			//
+			// In addition, the network poller's accept implementation also
+			// deals with ECONNABORTED, in case a socket is closed before it is
+			// pulled from our listen queue.
+			return false
+		default:
+			// No error or some unrecognized error, treat this Read operation
+			// as completed.
+			return true
+		}
+	})
+	if doErr != nil {
+		return 0, nil, doErr
+	}
+
+	return newFD, sa, err
+}

--- a/fd_linux_lt_1.12.go
+++ b/fd_linux_lt_1.12.go
@@ -1,0 +1,14 @@
+//+build !go1.12,linux
+
+package vsock
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func (lfd *sysListenFD) accept4(flags int) (int, unix.Sockaddr, error) {
+	// In Go 1.11, accept on the raw file descriptor directly, because lfd.f
+	// may be attached to the runtime network poller, forcing this call to block
+	// even if Close is called.
+	return unix.Accept4(lfd.fd, flags)
+}

--- a/fd_linux_test.go
+++ b/fd_linux_test.go
@@ -11,18 +11,24 @@ import (
 var _ listenFD = &testListenFD{}
 
 type testListenFD struct {
-	accept4     func(flags int) (connFD, unix.Sockaddr, error)
-	bind        func(sa unix.Sockaddr) error
-	close       func() error
-	listen      func(n int) error
-	getsockname func() (unix.Sockaddr, error)
+	accept4        func(flags int) (connFD, unix.Sockaddr, error)
+	bind           func(sa unix.Sockaddr) error
+	close          func() error
+	listen         func(n int) error
+	getsockname    func() (unix.Sockaddr, error)
+	setNonblocking func(name string) error
 }
 
 func (lfd *testListenFD) Accept4(flags int) (connFD, unix.Sockaddr, error) { return lfd.accept4(flags) }
 func (lfd *testListenFD) Bind(sa unix.Sockaddr) error                      { return lfd.bind(sa) }
 func (lfd *testListenFD) Close() error                                     { return lfd.close() }
-func (lfd *testListenFD) Getsockname() (unix.Sockaddr, error)              { return lfd.getsockname() }
-func (lfd *testListenFD) Listen(n int) error                               { return lfd.listen(n) }
+func (lfd *testListenFD) EarlyClose() error {
+	// Share logic with close.
+	return lfd.close()
+}
+func (lfd *testListenFD) Getsockname() (unix.Sockaddr, error) { return lfd.getsockname() }
+func (lfd *testListenFD) Listen(n int) error                  { return lfd.listen(n) }
+func (lfd *testListenFD) SetNonblocking(name string) error    { return lfd.setNonblocking(name) }
 
 var _ connFD = &testConnFD{}
 
@@ -38,9 +44,13 @@ type testConnFD struct {
 	setWriteDeadline func(t time.Time) error
 }
 
-func (cfd *testConnFD) Read(b []byte) (int, error)          { return cfd.read(b) }
-func (cfd *testConnFD) Write(b []byte) (int, error)         { return cfd.write(b) }
-func (cfd *testConnFD) Close() error                        { return cfd.close() }
+func (cfd *testConnFD) Read(b []byte) (int, error)  { return cfd.read(b) }
+func (cfd *testConnFD) Write(b []byte) (int, error) { return cfd.write(b) }
+func (cfd *testConnFD) Close() error                { return cfd.close() }
+func (cfd *testConnFD) EarlyClose() error {
+	// Share logic with close.
+	return cfd.close()
+}
 func (cfd *testConnFD) Connect(sa unix.Sockaddr) error      { return cfd.connect(sa) }
 func (cfd *testConnFD) Getsockname() (unix.Sockaddr, error) { return cfd.getsockname() }
 func (cfd *testConnFD) SetNonblocking(name string) error    { return cfd.setNonblocking(name) }

--- a/fd_linux_test.go
+++ b/fd_linux_test.go
@@ -3,31 +3,47 @@
 package vsock
 
 import (
-	"os"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
 
-var _ fd = &testFD{}
+var _ listenFD = &testListenFD{}
 
-// A testFD is the test implementation of fd, with functions that can be set
-// for each of its methods.
-type testFD struct {
-	accept4     func(flags int) (fd, unix.Sockaddr, error)
+type testListenFD struct {
+	accept4     func(flags int) (connFD, unix.Sockaddr, error)
 	bind        func(sa unix.Sockaddr) error
 	close       func() error
-	connect     func(sa unix.Sockaddr) error
 	listen      func(n int) error
-	newFile     func(name string) *os.File
 	getsockname func() (unix.Sockaddr, error)
-	setNonblock func(nonblocking bool) error
 }
 
-func (fd *testFD) Accept4(flags int) (fd, unix.Sockaddr, error) { return fd.accept4(flags) }
-func (fd *testFD) Bind(sa unix.Sockaddr) error                  { return fd.bind(sa) }
-func (fd *testFD) Close() error                                 { return fd.close() }
-func (fd *testFD) Connect(sa unix.Sockaddr) error               { return fd.connect(sa) }
-func (fd *testFD) Getsockname() (unix.Sockaddr, error)          { return fd.getsockname() }
-func (fd *testFD) Listen(n int) error                           { return fd.listen(n) }
-func (fd *testFD) NewFile(name string) *os.File                 { return fd.newFile(name) }
-func (fd *testFD) SetNonblock(nonblocking bool) error           { return fd.setNonblock(nonblocking) }
+func (lfd *testListenFD) Accept4(flags int) (connFD, unix.Sockaddr, error) { return lfd.accept4(flags) }
+func (lfd *testListenFD) Bind(sa unix.Sockaddr) error                      { return lfd.bind(sa) }
+func (lfd *testListenFD) Close() error                                     { return lfd.close() }
+func (lfd *testListenFD) Getsockname() (unix.Sockaddr, error)              { return lfd.getsockname() }
+func (lfd *testListenFD) Listen(n int) error                               { return lfd.listen(n) }
+
+var _ connFD = &testConnFD{}
+
+type testConnFD struct {
+	read             func(b []byte) (int, error)
+	write            func(b []byte) (int, error)
+	close            func() error
+	connect          func(sa unix.Sockaddr) error
+	getsockname      func() (unix.Sockaddr, error)
+	setNonblocking   func(name string) error
+	setDeadline      func(t time.Time) error
+	setReadDeadline  func(t time.Time) error
+	setWriteDeadline func(t time.Time) error
+}
+
+func (cfd *testConnFD) Read(b []byte) (int, error)          { return cfd.read(b) }
+func (cfd *testConnFD) Write(b []byte) (int, error)         { return cfd.write(b) }
+func (cfd *testConnFD) Close() error                        { return cfd.close() }
+func (cfd *testConnFD) Connect(sa unix.Sockaddr) error      { return cfd.connect(sa) }
+func (cfd *testConnFD) Getsockname() (unix.Sockaddr, error) { return cfd.getsockname() }
+func (cfd *testConnFD) SetNonblocking(name string) error    { return cfd.setNonblocking(name) }
+func (cfd *testConnFD) SetDeadline(t time.Time) error       { return cfd.setDeadline(t) }
+func (cfd *testConnFD) SetReadDeadline(t time.Time) error   { return cfd.setReadDeadline(t) }
+func (cfd *testConnFD) SetWriteDeadline(t time.Time) error  { return cfd.setWriteDeadline(t) }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,6 @@
 module github.com/mdlayher/vsock
 
-require golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8
+require (
+	github.com/google/go-cmp v0.2.0
+	golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
+github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8 h1:YoY1wS6JYVRpIfFngRf2HHo9R9dAne3xbkGOQ5rJXjU=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/vsutil/vsutil.go
+++ b/internal/vsutil/vsutil.go
@@ -1,0 +1,42 @@
+// Package vsutil provides added functionality for package vsock-internal use.
+package vsutil
+
+import (
+	"net"
+	"time"
+)
+
+// Accept blocks until a single connection is accepted by the net.Listener, and
+// then closes the net.Listener.  If timeout is non-zero, the listener will be
+// closed after the timeout expires, even if no connection was accepted.
+func Accept(l net.Listener, timeout time.Duration) (net.Conn, error) {
+	defer l.Close()
+
+	// This function accomodates both Go1.12+ and Go1.11- functionality to allow
+	// net.Listener.Accept to be canceled by net.Listener.Close.
+	//
+	// If a timeout is set, set up a timer to close the listener and either:
+	// - Go1.12+: unblock the call to Accept
+	// - Go1.11 : eventually halt the loop due to closed file descriptor
+	cancel := func() {}
+	if timeout != 0 {
+		timer := time.AfterFunc(timeout, func() { _ = l.Close() })
+		cancel = func() { timer.Stop() }
+	}
+
+	for {
+		c, err := l.Accept()
+		if err != nil {
+			if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
+				time.Sleep(250 * time.Millisecond)
+				continue
+			}
+
+			return nil, err
+		}
+
+		// Got a connection, stop the timer.
+		cancel()
+		return c, nil
+	}
+}

--- a/listener_linux.go
+++ b/listener_linux.go
@@ -13,7 +13,7 @@ var _ net.Listener = &listener{}
 // A listener is the net.Listener implementation for connection-oriented
 // VM sockets.
 type listener struct {
-	fd   fd
+	fd   listenFD
 	addr *Addr
 }
 
@@ -45,18 +45,17 @@ func listenStream(port uint32) (net.Listener, error) {
 		return nil, err
 	}
 
-	fd, err := unix.Socket(unix.AF_VSOCK, unix.SOCK_STREAM, 0)
+	lfd, err := newListenFD()
 	if err != nil {
 		return nil, err
 	}
 
-	lfd := &sysFD{fd: fd}
 	return listenStreamLinuxHandleError(lfd, cid, port)
 }
 
 // listenStreamLinuxHandleError ensures that any errors from listenStreamLinux
 // result in the socket being cleaned up properly.
-func listenStreamLinuxHandleError(lfd fd, cid, port uint32) (net.Listener, error) {
+func listenStreamLinuxHandleError(lfd listenFD, cid, port uint32) (net.Listener, error) {
 	l, err := listenStreamLinux(lfd, cid, port)
 	if err != nil {
 		// If any system calls fail during setup, the socket must be closed
@@ -72,7 +71,7 @@ func listenStreamLinuxHandleError(lfd fd, cid, port uint32) (net.Listener, error
 const listenBacklog = 32
 
 // listenStreamLinux is the entry point for tests on Linux.
-func listenStreamLinux(lfd fd, cid, port uint32) (net.Listener, error) {
+func listenStreamLinux(lfd listenFD, cid, port uint32) (net.Listener, error) {
 	// Zero-value for "any port" is friendlier in Go than a constant.
 	if port == 0 {
 		port = unix.VMADDR_PORT_ANY
@@ -81,10 +80,6 @@ func listenStreamLinux(lfd fd, cid, port uint32) (net.Listener, error) {
 	sa := &unix.SockaddrVM{
 		CID:  cid,
 		Port: port,
-	}
-
-	if err := lfd.SetNonblock(true); err != nil {
-		return nil, err
 	}
 
 	if err := lfd.Bind(sa); err != nil {

--- a/listener_linux.go
+++ b/listener_linux.go
@@ -30,12 +30,12 @@ func (l *listener) Accept() (net.Conn, error) {
 	}
 
 	savm := sa.(*unix.SockaddrVM)
-	remoteAddr := &Addr{
+	remote := &Addr{
 		ContextID: savm.CID,
 		Port:      savm.Port,
 	}
 
-	return newConn(cfd, l.addr.fileName(), l.addr, remoteAddr)
+	return newConn(cfd, l.addr, remote)
 }
 
 // listenStream is the entry point for ListenStream on Linux.

--- a/listener_linux_test.go
+++ b/listener_linux_test.go
@@ -2,20 +2,16 @@ package vsock
 
 import (
 	"errors"
-	"os"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"golang.org/x/sys/unix"
 )
 
 func Test_listenStreamLinuxHandleError(t *testing.T) {
-	var (
-		closed      bool
-		nonblocking bool
-	)
+	var closed bool
 
-	lfd := &testFD{
+	lfd := &testListenFD{
 		// Track when fd.Close is called.
 		close: func() error {
 			closed = true
@@ -25,24 +21,14 @@ func Test_listenStreamLinuxHandleError(t *testing.T) {
 		bind: func(sa unix.Sockaddr) error {
 			return errors.New("error during bind")
 		},
-		setNonblock: func(n bool) error {
-			nonblocking = n
-			return nil
-		},
 	}
 
 	if _, err := listenStreamLinuxHandleError(lfd, 0, 0); err == nil {
 		t.Fatal("expected an error, but none occurred")
 	}
 
-	if want, got := true, nonblocking; want != got {
-		t.Fatalf("unexpected nonblocking value:\n- want: %v\n-  got: %v",
-			want, got)
-	}
-
-	if want, got := true, closed; want != got {
-		t.Fatalf("unexpected socket close value:\n- want: %v\n-  got: %v",
-			want, got)
+	if diff := cmp.Diff(true, closed); diff != "" {
+		t.Fatalf("unexpected closed value (-want +got):\n%s", diff)
 	}
 }
 
@@ -59,19 +45,17 @@ func Test_listenStreamLinuxPortZero(t *testing.T) {
 	}
 
 	bindFn := func(sa unix.Sockaddr) error {
-		if want, got := lsa, sa; !reflect.DeepEqual(want, got) {
-			t.Fatalf("unexpected bind sockaddr:\n- want: %#v\n-  got: %#v",
-				want, got)
+		if diff := cmp.Diff(lsa, sa.(*unix.SockaddrVM), cmp.AllowUnexported(*lsa)); diff != "" {
+			t.Fatalf("unexpected bind sockaddr (-want +got):\n%s", diff)
 		}
 
 		return nil
 	}
 
-	lfd := &testFD{
+	lfd := &testListenFD{
 		bind:        bindFn,
 		listen:      func(n int) error { return nil },
 		getsockname: func() (unix.Sockaddr, error) { return lsa, nil },
-		setNonblock: func(n bool) error { return nil },
 	}
 
 	if _, err := listenStreamLinux(lfd, cid, port); err != nil {
@@ -90,33 +74,23 @@ func Test_listenStreamLinuxFull(t *testing.T) {
 		Port: port,
 	}
 
-	lfd := &testFD{
+	lfd := &testListenFD{
 		bind: func(sa unix.Sockaddr) error {
-			if want, got := lsa, sa; !reflect.DeepEqual(want, got) {
-				t.Fatalf("unexpected bind sockaddr:\n- want: %#v\n-  got: %#v",
-					want, got)
+			if diff := cmp.Diff(lsa, sa.(*unix.SockaddrVM), cmp.AllowUnexported(*lsa)); diff != "" {
+				t.Fatalf("unexpected bind sockaddr (-want +got):\n%s", diff)
 			}
 
 			return nil
 		},
 		listen: func(n int) error {
-			if want, got := listenBacklog, n; want != got {
-				t.Fatalf("unexpected listen backlog:\n- want: %d\n-  got: %d",
-					want, got)
+			if diff := cmp.Diff(listenBacklog, n); diff != "" {
+				t.Fatalf("unexpected listen backlog (-want +got):\n%s", diff)
 			}
 
 			return nil
 		},
 		getsockname: func() (unix.Sockaddr, error) {
 			return lsa, nil
-		},
-		setNonblock: func(nonblocking bool) error {
-			if want, got := true, nonblocking; !reflect.DeepEqual(want, got) {
-				t.Fatalf("unexpected set nonblocking value:\n- want: %#v\n-  got: %#v",
-					want, got)
-			}
-
-			return nil
 		},
 	}
 
@@ -127,39 +101,31 @@ func Test_listenStreamLinuxFull(t *testing.T) {
 
 	l := nl.(*listener)
 
-	if want, got := cid, l.addr.ContextID; want != got {
-		t.Fatalf("unexpected listener context ID:\n- want: %d\n-  got: %d",
-			want, got)
+	want := &Addr{
+		ContextID: cid,
+		Port:      port,
 	}
-	if want, got := port, l.addr.Port; want != got {
-		t.Fatalf("unexpected listener context ID:\n- want: %d\n-  got: %d",
-			want, got)
+
+	if diff := cmp.Diff(want, l.Addr()); diff != "" {
+		t.Fatalf("unexpected local address (-want +got):\n%s", diff)
 	}
 }
 
 func Test_listenerAccept(t *testing.T) {
 	const (
-		connFD uintptr = 10
-
 		cid  uint32 = 3
 		port uint32 = 1024
 	)
 
-	accept4Fn := func(flags int) (fd, unix.Sockaddr, error) {
-		if want, got := 0, flags; want != got {
-			t.Fatalf("unexpected accept4 flags:\n- want: %d\n-  got: %d",
-				want, got)
+	var nonblocking bool
+	accept4Fn := func(flags int) (connFD, unix.Sockaddr, error) {
+		if diff := cmp.Diff(0, flags); diff != "" {
+			t.Fatalf("unexpected accept4 flags (-want +got):\n%s", diff)
 		}
 
-		acceptFD := &testFD{
-			newFile: func(name string) *os.File {
-				return os.NewFile(connFD, name)
-			},
-			setNonblock: func(nonblocking bool) error {
-				if want, got := true, nonblocking; !reflect.DeepEqual(want, got) {
-					t.Fatalf("unexpected set nonblocking value:\n- want: %#v\n-  got: %#v",
-						want, got)
-				}
+		acceptFD := &testConnFD{
+			setNonblocking: func(_ string) error {
+				nonblocking = true
 				return nil
 			},
 		}
@@ -178,7 +144,7 @@ func Test_listenerAccept(t *testing.T) {
 	}
 
 	l := &listener{
-		fd: &testFD{
+		fd: &testListenFD{
 			accept4: accept4Fn,
 		},
 		addr: localAddr,
@@ -191,9 +157,12 @@ func Test_listenerAccept(t *testing.T) {
 
 	c := nc.(*conn)
 
-	if want, got := localAddr, c.LocalAddr(); !reflect.DeepEqual(want, got) {
-		t.Fatalf("unexpected conn local address:\n- want: %#v\n-  got: %#v",
-			want, got)
+	if !nonblocking {
+		t.Fatal("file descriptor was not set to non-blocking mode")
+	}
+
+	if diff := cmp.Diff(localAddr, c.LocalAddr()); diff != "" {
+		t.Fatalf("unexpected local address (-want +got):\n%s", diff)
 	}
 
 	remoteAddr := &Addr{
@@ -201,13 +170,7 @@ func Test_listenerAccept(t *testing.T) {
 		Port:      port,
 	}
 
-	if want, got := remoteAddr, c.RemoteAddr(); !reflect.DeepEqual(want, got) {
-		t.Fatalf("unexpected conn remote address:\n- want: %#v\n-  got: %#v",
-			want, got)
-	}
-
-	if want, got := connFD, c.file.Fd(); want != got {
-		t.Fatalf("unexpected conn file descriptor:\n- want: %d\n-  got: %d",
-			want, got)
+	if diff := cmp.Diff(remoteAddr, c.RemoteAddr()); diff != "" {
+		t.Fatalf("unexpected remote address (-want +got):\n%s", diff)
 	}
 }

--- a/vsock_test.go
+++ b/vsock_test.go
@@ -65,7 +65,6 @@ func TestUnblockAcceptAfterClose(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-
 	wg.Add(1)
 
 	go func() {
@@ -80,13 +79,17 @@ func TestUnblockAcceptAfterClose(t *testing.T) {
 		}
 	}()
 
+	time.AfterFunc(10*time.Second, func() {
+		panic("took too long waiting for listener to close")
+	})
+
 	time.Sleep(100 * time.Millisecond)
 
 	if err := listener.Close(); err != nil {
 		t.Fatalf("failed to close listener: %v", err)
 	}
 
-	done := make(chan bool)
+	done := make(chan struct{})
 	go func() {
 		wg.Wait()
 		close(done)
@@ -95,7 +98,6 @@ func TestUnblockAcceptAfterClose(t *testing.T) {
 	select {
 	case <-done:
 		t.Log("done")
-		return
 	case <-time.After(5 * time.Second):
 		t.Fatal("timeout waiting accept to unblock")
 	}


### PR DESCRIPTION
A draft that should make all the runtime network poller magic work properly. I need to overhaul the tests now too.

> - net.Listener that can accept and wait indefinitely without EAGAIN, but also be closed while blocking

```
matt@servnerr-3:~$ ./vscp -r -p 1024 -t 5s
2019/03/14 22:28:39 receive: listening: host(2):1024
2019/03/14 22:28:44 vscp: receive: failed to accept: use of closed file
```

> - net.Conn that can have timeouts set and be closed concurrently (already done?)

```
matt@servnerr-3:~$ ./vscp -r -p 1024 -t 5s
2019/03/14 22:28:54 receive: listening: host(2):1024
abc
2019/03/14 22:29:01 vscp: receive: failed to receive data: read vsock host(2):1024: i/o timeout
```

Fixes #25.