### PR TITLE
vsock: require Go version 1.11+ for Conn,Listener

### DIFF
--- a/conn_linux.go
+++ b/conn_linux.go
@@ -1,4 +1,4 @@
-//+build linux
+//+build go1.11,linux
 
 package vsock
 

--- a/listener_linux.go
+++ b/listener_linux.go
@@ -1,4 +1,4 @@
-//+build linux
+//+build go1.11,linux
 
 package vsock
 


### PR DESCRIPTION
Require a compile time check of the Go compiler version, to avoid situations where a binary using this package is generated but not working properly.