### PR TITLE
vsock: set SOCK_CLOEXEC in unix.Socket calls

### DIFF
--- a/listener_linux_test.go
+++ b/listener_linux_test.go
@@ -125,7 +125,7 @@ func Test_listenerAccept(t *testing.T) {
 
 	var nonblocking bool
 	accept4Fn := func(flags int) (connFD, unix.Sockaddr, error) {
-		if diff := cmp.Diff(0, flags); diff != "" {
+		if diff := cmp.Diff(unix.SOCK_CLOEXEC, flags); diff != "" {
 			t.Fatalf("unexpected accept4 flags (-want +got):\n%s", diff)
 		}
 


### PR DESCRIPTION
See: https://github.com/mdlayher/netlink/issues/137.

Go 1.11.x:

```
matt@vmkube01:~$ sudo ./vsock.test -test.v
=== RUN   Test_dialLinuxErrorClosesFile
--- PASS: Test_dialLinuxErrorClosesFile (0.00s)
=== RUN   Test_dialLinuxFull
--- PASS: Test_dialLinuxFull (0.00s)
=== RUN   Test_listenLinuxErrorClosesFile
--- PASS: Test_listenLinuxErrorClosesFile (0.00s)
=== RUN   Test_listenLinuxPortZero
--- PASS: Test_listenLinuxPortZero (0.00s)
=== RUN   Test_listenLinuxFull
--- PASS: Test_listenLinuxFull (0.00s)
=== RUN   Test_listenerAccept
--- PASS: Test_listenerAccept (0.00s)
=== RUN   Test_opError
=== RUN   Test_opError/nil_error
=== RUN   Test_opError/unknown
=== RUN   Test_opError/EOF
=== RUN   Test_opError/ENOTCONN
=== RUN   Test_opError/PathError_ENOTCONN
=== RUN   Test_opError/ErrClosed
=== RUN   Test_opError/EBADF
=== RUN   Test_opError/string_use_of_closed
=== RUN   Test_opError/special_PathError_/dev/vsock
=== RUN   Test_opError/op_close
=== RUN   Test_opError/op_dial
=== RUN   Test_opError/op_raw-read
=== RUN   Test_opError/op_raw-write
=== RUN   Test_opError/op_read
=== RUN   Test_opError/op_write
=== RUN   Test_opError/op_accept
=== RUN   Test_opError/op_listen
=== RUN   Test_opError/op_raw-control
=== RUN   Test_opError/op_set
=== RUN   Test_opError/op_syscall-conn
--- PASS: Test_opError (0.01s)
    --- PASS: Test_opError/nil_error (0.00s)
    --- PASS: Test_opError/unknown (0.00s)
    --- PASS: Test_opError/EOF (0.00s)
    --- PASS: Test_opError/ENOTCONN (0.00s)
    --- PASS: Test_opError/PathError_ENOTCONN (0.00s)
    --- PASS: Test_opError/ErrClosed (0.00s)
    --- PASS: Test_opError/EBADF (0.00s)
    --- PASS: Test_opError/string_use_of_closed (0.00s)
    --- PASS: Test_opError/special_PathError_/dev/vsock (0.00s)
    --- PASS: Test_opError/op_close (0.00s)
    --- PASS: Test_opError/op_dial (0.00s)
    --- PASS: Test_opError/op_raw-read (0.00s)
    --- PASS: Test_opError/op_raw-write (0.00s)
    --- PASS: Test_opError/op_read (0.00s)
    --- PASS: Test_opError/op_write (0.00s)
    --- PASS: Test_opError/op_accept (0.00s)
    --- PASS: Test_opError/op_listen (0.00s)
    --- PASS: Test_opError/op_raw-control (0.00s)
    --- PASS: Test_opError/op_set (0.00s)
    --- PASS: Test_opError/op_syscall-conn (0.00s)
=== RUN   TestAddr_fileName
=== RUN   TestAddr_fileName/vsock:hypervisor(0):10
=== RUN   TestAddr_fileName/vsock:reserved(1):20
=== RUN   TestAddr_fileName/vsock:host(2):30
=== RUN   TestAddr_fileName/vsock:vm(3):40
--- PASS: TestAddr_fileName (0.00s)
    --- PASS: TestAddr_fileName/vsock:hypervisor(0):10 (0.00s)
    --- PASS: TestAddr_fileName/vsock:reserved(1):20 (0.00s)
    --- PASS: TestAddr_fileName/vsock:host(2):30 (0.00s)
    --- PASS: TestAddr_fileName/vsock:vm(3):40 (0.00s)
=== RUN   TestIntegrationListenerSetDeadlineError
--- PASS: TestIntegrationListenerSetDeadlineError (0.00s)
    integration_linux_lt_1.12_test.go:22: OK error: set vsock vm(3):1188: vsock: listener deadlines not supported on go1.11.5
=== RUN   TestIntegrationConnSyscallConnError
--- PASS: TestIntegrationConnSyscallConnError (0.00s)
    integration_linux_lt_1.12_test.go:41: OK error: syscall-conn vsock vm(3):1190: vsock: syscall conn not supported on go1.11.5
=== RUN   TestIntegrationListenerUnblockAcceptAfterClose
--- PASS: TestIntegrationListenerUnblockAcceptAfterClose (0.25s)
    integration_linux_test.go:31: start accept
    integration_linux_test.go:33: after accept
=== RUN   TestIntegrationContextIDGuest
--- PASS: TestIntegrationContextIDGuest (0.00s)
    integration_linux_test.go:81: guest context ID: 3
=== RUN   TestIntegrationContextIDHost
--- SKIP: TestIntegrationContextIDHost (0.00s)
    integration_linux_test.go:92: skipping, machine is not a hypervisor
=== RUN   TestIntegrationNettestTestConn
=== RUN   TestIntegrationNettestTestConn/BasicIO
=== RUN   TestIntegrationNettestTestConn/PingPong
=== RUN   TestIntegrationNettestTestConn/RacyRead
=== RUN   TestIntegrationNettestTestConn/RacyWrite
=== RUN   TestIntegrationNettestTestConn/ReadTimeout
=== RUN   TestIntegrationNettestTestConn/WriteTimeout
=== RUN   TestIntegrationNettestTestConn/PastTimeout
=== RUN   TestIntegrationNettestTestConn/PresentTimeout
=== RUN   TestIntegrationNettestTestConn/FutureTimeout
=== RUN   TestIntegrationNettestTestConn/CloseTimeout
=== RUN   TestIntegrationNettestTestConn/ConcurrentMethods
--- PASS: TestIntegrationNettestTestConn (0.71s)
    --- PASS: TestIntegrationNettestTestConn/BasicIO (0.17s)
    --- PASS: TestIntegrationNettestTestConn/PingPong (0.02s)
    --- PASS: TestIntegrationNettestTestConn/RacyRead (0.12s)
    --- PASS: TestIntegrationNettestTestConn/RacyWrite (0.01s)
    --- PASS: TestIntegrationNettestTestConn/ReadTimeout (0.00s)
    --- PASS: TestIntegrationNettestTestConn/WriteTimeout (0.02s)
    --- PASS: TestIntegrationNettestTestConn/PastTimeout (0.00s)
    --- PASS: TestIntegrationNettestTestConn/PresentTimeout (0.10s)
    --- PASS: TestIntegrationNettestTestConn/FutureTimeout (0.11s)
    --- PASS: TestIntegrationNettestTestConn/CloseTimeout (0.11s)
    --- PASS: TestIntegrationNettestTestConn/ConcurrentMethods (0.05s)
=== RUN   TestIntegrationNettestTestListener
--- SKIP: TestIntegrationNettestTestListener (0.00s)
    integration_linux_test.go:160: skipping, enable once https://go-review.googlesource.com/c/net/+/123056 is merged
PASS
```

Go 1.12.x:

```
matt@vmkube01:~$ sudo ./vsock.test -test.v
=== RUN   Test_dialLinuxErrorClosesFile
--- PASS: Test_dialLinuxErrorClosesFile (0.00s)
=== RUN   Test_dialLinuxFull
--- PASS: Test_dialLinuxFull (0.00s)
=== RUN   Test_listenLinuxErrorClosesFile
--- PASS: Test_listenLinuxErrorClosesFile (0.00s)
=== RUN   Test_listenLinuxPortZero
--- PASS: Test_listenLinuxPortZero (0.00s)
=== RUN   Test_listenLinuxFull
--- PASS: Test_listenLinuxFull (0.00s)
=== RUN   Test_listenerAccept
--- PASS: Test_listenerAccept (0.00s)
=== RUN   Test_opError
=== RUN   Test_opError/nil_error
=== RUN   Test_opError/unknown
=== RUN   Test_opError/EOF
=== RUN   Test_opError/ENOTCONN
=== RUN   Test_opError/PathError_ENOTCONN
=== RUN   Test_opError/ErrClosed
=== RUN   Test_opError/EBADF
=== RUN   Test_opError/string_use_of_closed
=== RUN   Test_opError/special_PathError_/dev/vsock
=== RUN   Test_opError/op_close
=== RUN   Test_opError/op_dial
=== RUN   Test_opError/op_raw-read
=== RUN   Test_opError/op_raw-write
=== RUN   Test_opError/op_read
=== RUN   Test_opError/op_write
=== RUN   Test_opError/op_accept
=== RUN   Test_opError/op_listen
=== RUN   Test_opError/op_raw-control
=== RUN   Test_opError/op_set
=== RUN   Test_opError/op_syscall-conn
--- PASS: Test_opError (0.01s)
    --- PASS: Test_opError/nil_error (0.00s)
    --- PASS: Test_opError/unknown (0.00s)
    --- PASS: Test_opError/EOF (0.00s)
    --- PASS: Test_opError/ENOTCONN (0.00s)
    --- PASS: Test_opError/PathError_ENOTCONN (0.00s)
    --- PASS: Test_opError/ErrClosed (0.00s)
    --- PASS: Test_opError/EBADF (0.00s)
    --- PASS: Test_opError/string_use_of_closed (0.00s)
    --- PASS: Test_opError/special_PathError_/dev/vsock (0.00s)
    --- PASS: Test_opError/op_close (0.00s)
    --- PASS: Test_opError/op_dial (0.00s)
    --- PASS: Test_opError/op_raw-read (0.00s)
    --- PASS: Test_opError/op_raw-write (0.00s)
    --- PASS: Test_opError/op_read (0.00s)
    --- PASS: Test_opError/op_write (0.00s)
    --- PASS: Test_opError/op_accept (0.00s)
    --- PASS: Test_opError/op_listen (0.00s)
    --- PASS: Test_opError/op_raw-control (0.00s)
    --- PASS: Test_opError/op_set (0.00s)
    --- PASS: Test_opError/op_syscall-conn (0.00s)
=== RUN   TestAddr_fileName
=== RUN   TestAddr_fileName/vsock:hypervisor(0):10
=== RUN   TestAddr_fileName/vsock:reserved(1):20
=== RUN   TestAddr_fileName/vsock:host(2):30
=== RUN   TestAddr_fileName/vsock:vm(3):40
--- PASS: TestAddr_fileName (0.00s)
    --- PASS: TestAddr_fileName/vsock:hypervisor(0):10 (0.00s)
    --- PASS: TestAddr_fileName/vsock:reserved(1):20 (0.00s)
    --- PASS: TestAddr_fileName/vsock:host(2):30 (0.00s)
    --- PASS: TestAddr_fileName/vsock:vm(3):40 (0.00s)
=== RUN   TestIntegrationListenerUnblockAcceptTimeout
--- PASS: TestIntegrationListenerUnblockAcceptTimeout (0.10s)
=== RUN   TestIntegrationConnShutdown
--- PASS: TestIntegrationConnShutdown (0.00s)
=== RUN   TestIntegrationConnSyscallConn
--- PASS: TestIntegrationConnSyscallConn (0.00s)
=== RUN   TestIntegrationListenerUnblockAcceptAfterClose
--- PASS: TestIntegrationListenerUnblockAcceptAfterClose (0.10s)
    integration_linux_test.go:31: start accept
    integration_linux_test.go:33: after accept
=== RUN   TestIntegrationContextIDGuest
--- PASS: TestIntegrationContextIDGuest (0.00s)
    integration_linux_test.go:81: guest context ID: 3
=== RUN   TestIntegrationContextIDHost
--- SKIP: TestIntegrationContextIDHost (0.00s)
    integration_linux_test.go:92: skipping, machine is not a hypervisor
=== RUN   TestIntegrationNettestTestConn
=== RUN   TestIntegrationNettestTestConn/BasicIO
=== RUN   TestIntegrationNettestTestConn/PingPong
=== RUN   TestIntegrationNettestTestConn/RacyRead
=== RUN   TestIntegrationNettestTestConn/RacyWrite
=== RUN   TestIntegrationNettestTestConn/ReadTimeout
=== RUN   TestIntegrationNettestTestConn/WriteTimeout
=== RUN   TestIntegrationNettestTestConn/PastTimeout
=== RUN   TestIntegrationNettestTestConn/PresentTimeout
=== RUN   TestIntegrationNettestTestConn/FutureTimeout
=== RUN   TestIntegrationNettestTestConn/CloseTimeout
=== RUN   TestIntegrationNettestTestConn/ConcurrentMethods
--- PASS: TestIntegrationNettestTestConn (0.58s)
    --- PASS: TestIntegrationNettestTestConn/BasicIO (0.08s)
    --- PASS: TestIntegrationNettestTestConn/PingPong (0.01s)
    --- PASS: TestIntegrationNettestTestConn/RacyRead (0.08s)
    --- PASS: TestIntegrationNettestTestConn/RacyWrite (0.01s)
    --- PASS: TestIntegrationNettestTestConn/ReadTimeout (0.00s)
    --- PASS: TestIntegrationNettestTestConn/WriteTimeout (0.02s)
    --- PASS: TestIntegrationNettestTestConn/PastTimeout (0.00s)
    --- PASS: TestIntegrationNettestTestConn/PresentTimeout (0.10s)
    --- PASS: TestIntegrationNettestTestConn/FutureTimeout (0.11s)
    --- PASS: TestIntegrationNettestTestConn/CloseTimeout (0.11s)
    --- PASS: TestIntegrationNettestTestConn/ConcurrentMethods (0.06s)
=== RUN   TestIntegrationNettestTestListener
--- SKIP: TestIntegrationNettestTestListener (0.00s)
    integration_linux_test.go:160: skipping, enable once https://go-review.googlesource.com/c/net/+/123056 is merged
PASS
```