### PR TITLE
Support blocking mode for Go 1.10

### DIFF
--- a/.builds/go-1.10.yml
+++ b/.builds/go-1.10.yml
@@ -1,0 +1,21 @@
+image: archlinux
+packages:
+  - wget
+sources:
+  - https://github.com/mdlayher/vsock
+environment:
+  GO111MODULE: "on"
+tasks:
+  - install: |
+      wget -q https://dl.google.com/go/go1.10.8.linux-amd64.tar.gz
+      sudo tar -C /usr/local -xzf go1.10.8.linux-amd64.tar.gz
+      sudo ln -s /usr/local/go/bin/go /usr/bin/go
+  - build: |
+      go version
+      cd vsock/
+      go get golang.org/x/lint/golint
+      /home/build/go/bin/golint -set_exit_status ./...
+      # Enable access to the vsock device for tests.
+      sudo modprobe vhost_vsock
+      sudo chmod 666 /dev/vsock
+      go test -v -race ./...

--- a/.builds/go-1.10.yml
+++ b/.builds/go-1.10.yml
@@ -3,8 +3,6 @@ packages:
   - wget
 sources:
   - https://github.com/mdlayher/vsock
-environment:
-  GO111MODULE: "on"
 tasks:
   - install: |
       wget -q https://dl.google.com/go/go1.10.8.linux-amd64.tar.gz
@@ -12,7 +10,11 @@ tasks:
       sudo ln -s /usr/local/go/bin/go /usr/bin/go
   - build: |
       go version
-      cd vsock/
+      # Force build in GOPATH mode because Go 1.10 doesn't support modules.
+      mkdir -p  /home/build/go/src/github.com/mdlayher/
+      mv vsock /home/build/go/src/github.com/mdlayher/
+      cd /home/build/go/src/github.com/mdlayher/vsock
+      go get -d -t -v ./...
       go get golang.org/x/lint/golint
       /home/build/go/bin/golint -set_exit_status ./...
       # Enable access to the vsock device for tests.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ This package supports varying levels of functionality depending on the version
 of Go used during compilation. The `Listener` and `Conn` types produced by this
 package are backed by non-blocking I/O, in order to integrate with Go's runtime
 network poller in Go 1.11+. Additional functionality is available starting in Go
-1.12+. Go 1.10 and prior versions of Go **are not supported** and will produce
-a compilation error when trying to build this package.
+1.12+. Go 1.10 and prior versions of Go **are not supported**.
 
 A comprehensive list of functionality for supported Go versions can be found on
 [package vsock's GoDoc page](https://godoc.org/github.com/mdlayher/vsock#hdr-Go_version_support).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This package supports varying levels of functionality depending on the version
 of Go used during compilation. The `Listener` and `Conn` types produced by this
 package are backed by non-blocking I/O, in order to integrate with Go's runtime
 network poller in Go 1.11+. Additional functionality is available starting in Go
-1.12+. Go 1.10 and prior versions of Go **are not supported**.
+1.12+. The older Go 1.10 is only supported in a blocking-only mode.
 
 A comprehensive list of functionality for supported Go versions can be found on
 [package vsock's GoDoc page](https://godoc.org/github.com/mdlayher/vsock#hdr-Go_version_support).

--- a/doc.go
+++ b/doc.go
@@ -42,8 +42,6 @@
 //
 // Go 1.10 and below are not supported. The runtime network poller integration
 // required by this package is not available in Go versions prior to Go 1.11.
-// Unsupported versions of Go will produce a compilation error when trying to
-// build this package.
 //
 // Stability
 //

--- a/doc.go
+++ b/doc.go
@@ -40,8 +40,16 @@
 //     - CloseRead and CloseWrite are not supported and will always return an error
 //     - SyscallConn is not supported and will always return an error
 //
-// Go 1.10 and below are not supported. The runtime network poller integration
-// required by this package is not available in Go versions prior to Go 1.11.
+// Go 1.10 (not recommended):
+//   - *Listener:
+//     - Accept blocks until a connection is received
+//       CPU cycle consumption
+//     - Close makes Accept return a permanent error on the next loop iteration
+//     - SetDeadline is not supported and will always return an error
+//   - *Conn:
+//     - SetDeadline is not supported and will always return an error
+//     - CloseRead and CloseWrite are not supported and will always return an error
+//     - SyscallConn is not supported and will always return an error
 //
 // Stability
 //

--- a/fd_linux.go
+++ b/fd_linux.go
@@ -162,17 +162,7 @@ func (cfd *sysConnFD) Shutdown(how int) error {
 }
 
 func (cfd *sysConnFD) SetDeadline(t time.Time, typ deadlineType) error {
-	switch typ {
-	case deadline:
-		return cfd.f.SetDeadline(t)
-	case readDeadline:
-		return cfd.f.SetReadDeadline(t)
-	case writeDeadline:
-		return cfd.f.SetWriteDeadline(t)
-	default:
-		panicf("vsock: sysConnFD.SetDeadline method invoked with invalid deadline type constant: %d", typ)
-		return nil
-	}
+	return cfd.setDeadline(t, typ)
 }
 
 func (cfd *sysConnFD) SyscallConn() (syscall.RawConn, error) { return cfd.syscallConn() }

--- a/fd_linux.go
+++ b/fd_linux.go
@@ -62,16 +62,7 @@ func (lfd *sysListenFD) Getsockname() (unix.Sockaddr, error) { return unix.Getso
 func (lfd *sysListenFD) Listen(n int) error                  { return unix.Listen(lfd.fd, n) }
 
 func (lfd *sysListenFD) SetNonblocking(name string) error {
-	// From now on, we must perform non-blocking I/O, so that our
-	// net.Listener.Accept method can be interrupted by closing the socket.
-	if err := unix.SetNonblock(lfd.fd, true); err != nil {
-		return err
-	}
-
-	// Transition from blocking mode to non-blocking mode.
-	lfd.f = os.NewFile(uintptr(lfd.fd), name)
-
-	return nil
+	return lfd.setNonblocking(name)
 }
 
 // EarlyClose is a blocking version of Close, only used for cleanup before
@@ -146,16 +137,7 @@ func (cfd *sysConnFD) Getsockname() (unix.Sockaddr, error) { return unix.Getsock
 func (cfd *sysConnFD) EarlyClose() error { return unix.Close(cfd.fd) }
 
 func (cfd *sysConnFD) SetNonblocking(name string) error {
-	// From now on, we must perform non-blocking I/O, so that our deadline
-	// methods work, and the connection can be interrupted by net.Conn.Close.
-	if err := unix.SetNonblock(cfd.fd, true); err != nil {
-		return err
-	}
-
-	// Transition from blocking mode to non-blocking mode.
-	cfd.f = os.NewFile(uintptr(cfd.fd), name)
-
-	return nil
+	return cfd.setNonblocking(name)
 }
 
 // Non-blocking mode methods.

--- a/fd_linux_1.10.go
+++ b/fd_linux_1.10.go
@@ -1,0 +1,58 @@
+//+build go1.10,!go1.11,linux
+
+package vsock
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func (lfd *sysListenFD) accept4(flags int) (int, unix.Sockaddr, error) {
+	// In Go 1.11, accept on the raw file descriptor directly, because lfd.f
+	// may be attached to the runtime network poller, forcing this call to block
+	// even if Close is called.
+	return unix.Accept4(lfd.fd, flags)
+}
+
+func (lfd *sysListenFD) setNonblocking(name string) error {
+	// Go 1.10 doesn't support non-blocking I/O.
+	if err := unix.SetNonblock(lfd.fd, false); err != nil {
+		return err
+	}
+
+	lfd.f = os.NewFile(uintptr(lfd.fd), name)
+
+	return nil
+}
+
+func (*sysListenFD) setDeadline(_ time.Time) error {
+	// Listener deadlines won't work as expected in this version of Go, so
+	// return an early error.
+	return fmt.Errorf("vsock: listener deadlines not supported on %s", runtime.Version())
+}
+
+func (*sysConnFD) shutdown(_ int) error {
+	// Shutdown functionality is not available in this version on Go.
+	return fmt.Errorf("vsock: close conn read/write not supported on %s", runtime.Version())
+}
+
+func (*sysConnFD) syscallConn() (syscall.RawConn, error) {
+	// SyscallConn functionality is not available in this version on Go.
+	return nil, fmt.Errorf("vsock: syscall conn not supported on %s", runtime.Version())
+}
+
+func (cfd *sysConnFD) setNonblocking(name string) error {
+	// Go 1.10 doesn't support non-blocking I/O.
+	if err := unix.SetNonblock(cfd.fd, false); err != nil {
+		return err
+	}
+
+	cfd.f = os.NewFile(uintptr(cfd.fd), name)
+
+	return nil
+}

--- a/fd_linux_1.10.go
+++ b/fd_linux_1.10.go
@@ -56,3 +56,8 @@ func (cfd *sysConnFD) setNonblocking(name string) error {
 
 	return nil
 }
+
+func (cfd *sysConnFD) setDeadline(t time.Time, typ deadlineType) error {
+	// Deadline functionality is not available in this version on Go.
+	return fmt.Errorf("vsock: connection deadlines not supported on %s", runtime.Version())
+}

--- a/fd_linux_1.11.go
+++ b/fd_linux_1.11.go
@@ -60,3 +60,17 @@ func (cfd *sysConnFD) setNonblocking(name string) error {
 
 	return nil
 }
+
+func (cfd *sysConnFD) setDeadline(t time.Time, typ deadlineType) error {
+	switch typ {
+	case deadline:
+		return cfd.f.SetDeadline(t)
+	case readDeadline:
+		return cfd.f.SetReadDeadline(t)
+	case writeDeadline:
+		return cfd.f.SetWriteDeadline(t)
+	}
+
+	panicf("vsock: sysConnFD.SetDeadline method invoked with invalid deadline type constant: %d", typ)
+	return nil
+}

--- a/fd_linux_gteq_1.12.go
+++ b/fd_linux_gteq_1.12.go
@@ -96,3 +96,17 @@ func (cfd *sysConnFD) setNonblocking(name string) error {
 
 	return nil
 }
+
+func (cfd *sysConnFD) setDeadline(t time.Time, typ deadlineType) error {
+	switch typ {
+	case deadline:
+		return cfd.f.SetDeadline(t)
+	case readDeadline:
+		return cfd.f.SetReadDeadline(t)
+	case writeDeadline:
+		return cfd.f.SetWriteDeadline(t)
+	}
+
+	panicf("vsock: sysConnFD.SetDeadline method invoked with invalid deadline type constant: %d", typ)
+	return nil
+}

--- a/fd_linux_gteq_1.12.go
+++ b/fd_linux_gteq_1.12.go
@@ -3,6 +3,7 @@
 package vsock
 
 import (
+	"os"
 	"syscall"
 	"time"
 
@@ -52,6 +53,19 @@ func (lfd *sysListenFD) accept4(flags int) (int, unix.Sockaddr, error) {
 
 func (lfd *sysListenFD) setDeadline(t time.Time) error { return lfd.f.SetDeadline(t) }
 
+func (lfd *sysListenFD) setNonblocking(name string) error {
+	// From now on, we must perform non-blocking I/O, so that our
+	// net.Listener.Accept method can be interrupted by closing the socket.
+	if err := unix.SetNonblock(lfd.fd, true); err != nil {
+		return err
+	}
+
+	// Transition from blocking mode to non-blocking mode.
+	lfd.f = os.NewFile(uintptr(lfd.fd), name)
+
+	return nil
+}
+
 func (cfd *sysConnFD) shutdown(how int) error {
 	rc, err := cfd.f.SyscallConn()
 	if err != nil {
@@ -69,3 +83,16 @@ func (cfd *sysConnFD) shutdown(how int) error {
 }
 
 func (cfd *sysConnFD) syscallConn() (syscall.RawConn, error) { return cfd.f.SyscallConn() }
+
+func (cfd *sysConnFD) setNonblocking(name string) error {
+	// From now on, we must perform non-blocking I/O, so that our deadline
+	// methods work, and the connection can be interrupted by net.Conn.Close.
+	if err := unix.SetNonblock(cfd.fd, true); err != nil {
+		return err
+	}
+
+	// Transition from blocking mode to non-blocking mode.
+	cfd.f = os.NewFile(uintptr(cfd.fd), name)
+
+	return nil
+}

--- a/goversion_unsupported.go
+++ b/goversion_unsupported.go
@@ -1,9 +1,0 @@
-//+build !go1.11
-
-package vsock
-
-func init() {
-	// Intentionally break compilation on unsupported versions of Go, but
-	// produce a somewhat informative build failure output.
-	UpgradeGoCompilerToUseThisPackage
-}

--- a/integration_linux_gteq_1.11_test.go
+++ b/integration_linux_gteq_1.11_test.go
@@ -1,0 +1,63 @@
+//+build go1.11,linux
+
+package vsock_test
+
+import (
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mdlayher/vsock/internal/vsutil"
+)
+
+func TestIntegrationListenerUnblockAcceptAfterClose(t *testing.T) {
+	l, done := newListener(t)
+	defer done()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		t.Log("start accept")
+		_, err := vsutil.Accept(l, 10*time.Second)
+		t.Log("after accept")
+
+		nerr, ok := err.(*net.OpError)
+		if !ok {
+			t.Errorf("expected a net.OpError, but got: %#v", err)
+		}
+
+		if nerr.Temporary() {
+			t.Errorf("expected permanent error, but got temporary one: %v", err)
+		}
+
+		// We mimic what net.TCPConn does and return an error with the same
+		// string as internal/poll, so string matching is the best we can do
+		// for now.
+		if !strings.Contains(nerr.Err.Error(), "use of closed") {
+			t.Errorf("expected close network connection error, but got: %v", nerr.Err)
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	if err := l.Close(); err != nil {
+		t.Fatalf("failed to close listener: %v", err)
+	}
+
+	doneC := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(doneC)
+	}()
+
+	select {
+	case <-doneC:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting accept to unblock")
+	}
+}

--- a/integration_linux_test.go
+++ b/integration_linux_test.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"regexp"
 	"strconv"
-	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -17,56 +15,6 @@ import (
 	"github.com/mdlayher/vsock/internal/vsutil"
 	"golang.org/x/net/nettest"
 )
-
-func TestIntegrationListenerUnblockAcceptAfterClose(t *testing.T) {
-	l, done := newListener(t)
-	defer done()
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	go func() {
-		defer wg.Done()
-
-		t.Log("start accept")
-		_, err := vsutil.Accept(l, 10*time.Second)
-		t.Log("after accept")
-
-		nerr, ok := err.(*net.OpError)
-		if !ok {
-			t.Errorf("expected a net.OpError, but got: %#v", err)
-		}
-
-		if nerr.Temporary() {
-			t.Errorf("expected permanent error, but got temporary one: %v", err)
-		}
-
-		// We mimic what net.TCPConn does and return an error with the same
-		// string as internal/poll, so string matching is the best we can do
-		// for now.
-		if !strings.Contains(nerr.Err.Error(), "use of closed") {
-			t.Errorf("expected close network connection error, but got: %v", nerr.Err)
-		}
-	}()
-
-	time.Sleep(100 * time.Millisecond)
-
-	if err := l.Close(); err != nil {
-		t.Fatalf("failed to close listener: %v", err)
-	}
-
-	doneC := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(doneC)
-	}()
-
-	select {
-	case <-doneC:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timeout waiting accept to unblock")
-	}
-}
 
 func TestIntegrationContextIDGuest(t *testing.T) {
 	if vsutil.IsHypervisor(t) {


### PR DESCRIPTION
This reintroduces support for Go 1.10 but uses blocking mode instead.

LXD will be adding VM support which needs to work with Go 1.10 as well. See https://github.com/lxc/lxd/issues/6234.