### PR TITLE
vsock: add DialTimeout

### DIFF
--- a/vsock.go
+++ b/vsock.go
@@ -149,6 +149,20 @@ func Dial(contextID, port uint32) (*Conn, error) {
 	return c, nil
 }
 
+// DialTimeout acts like Dial but takes a timeout.
+func DialTimeout(contextID, port uint32, timeout time.Duration) (*Conn, error) {
+	c, err := dialTimeout(contextID, port, timeout)
+	if err != nil {
+		// No local address, but we have a remote address we can return.
+		return nil, opError(opDial, err, nil, &Addr{
+			ContextID: contextID,
+			Port:      port,
+		})
+	}
+
+	return c, nil
+}
+
 var _ net.Conn = &Conn{}
 var _ syscall.Conn = &Conn{}
 

--- a/vsock_others.go
+++ b/vsock_others.go
@@ -26,7 +26,8 @@ func (*listener) Addr() net.Addr                { return nil }
 func (*listener) Close() error                  { return errUnimplemented }
 func (*listener) SetDeadline(_ time.Time) error { return errUnimplemented }
 
-func dial(_, _ uint32) (*Conn, error) { return nil, errUnimplemented }
+func dial(_, _ uint32) (*Conn, error)                         { return nil, errUnimplemented }
+func dialTimeout(_, _ uint32, _ time.Duration) (*Conn, error) { return nil, errUnimplemented }
 
 type connFD struct{}
 


### PR DESCRIPTION
We need to use `Dial` with timeout feature in Kata, see https://github.com/kata-containers/runtime/issues/1917#issuecomment-625069513

Signed-off-by: Ning Bo <ning.bo9@zte.com.cn>