### PR TITLE
add ListenLocal for ease of testing

### DIFF
--- a/vsock.go
+++ b/vsock.go
@@ -87,7 +87,7 @@ func ListenLocal(port uint32) (*Listener, error) {
 	if err != nil {
 		// No remote address available.
 		return nil, opError(opListen, err, &Addr{
-			ContextID: 1,
+			ContextID: loopback,
 			Port:      port,
 		}, nil)
 	}

--- a/vsock_test.go
+++ b/vsock_test.go
@@ -1,6 +1,9 @@
 package vsock
 
 import (
+	"bytes"
+	"math/rand"
+	"sync"
 	"testing"
 )
 
@@ -16,9 +19,9 @@ func TestAddr_fileName(t *testing.T) {
 			s:    "vsock:hypervisor(0):10",
 		},
 		{
-			cid:  cidReserved,
+			cid:  loopback,
 			port: 20,
-			s:    "vsock:reserved(1):20",
+			s:    "vsock:loopback(1):20",
 		},
 		{
 			cid:  Host,
@@ -45,4 +48,59 @@ func TestAddr_fileName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestListenLocal(t *testing.T) {
+	const listenPort = 1024
+
+	var	testData = make([]byte, 1024)
+	_, err := rand.Read(testData)
+	if err != nil {
+		t.Fatalf("unable to prepare test data: %v", err)
+	}
+
+	listener, err := ListenLocal(listenPort)
+	if err != nil {
+		t.Fatalf("unable to listen on local CID: %v", err)
+	}
+	defer listener.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+
+		conn, err := listener.Accept()
+		if err != nil {
+			t.Fatalf("unable to accept on local CID: %v",  err)
+		}
+		defer conn.Close()
+
+		data := make([]byte, 1024)
+		_, err = conn.Read(data)
+		if err != nil {
+			t.Fatalf("unable to read on local CID: %v",  err)
+		}
+
+		if bytes.Compare(data, testData) != 0 {
+			t.Fatalf("read corrupted on local CID: %v",  err)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		conn, err := Dial(loopback, listenPort)
+		if err != nil {
+			t.Fatalf("unable to dial local CID(%d): %v", loopback, err)
+		}
+		defer conn.Close()
+
+		_, err = conn.Write(testData)
+		if err != nil {
+			t.Fatalf("unable to write to local CID: %v",  err)
+		}
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION
Per https://man7.org/linux/man-pages/man7/vsock.7.html, CID=0x1 can be thought as a loopback cid for local communication.
Adding the function for listening on CID=0x1 can make testing much simpler which is in my use case....Any thoughts?