### PR TITLE
Add FileListener()

### DIFF
--- a/listener_linux.go
+++ b/listener_linux.go
@@ -3,7 +3,9 @@
 package vsock
 
 import (
+	"fmt"
 	"net"
+	"os"
 	"time"
 
 	"golang.org/x/sys/unix"
@@ -47,6 +49,24 @@ func (l *listener) Accept() (net.Conn, error) {
 	return newConn(cfd, l.addr, remote)
 }
 
+// FileListener returns a network listener for the open file f.
+// It is the caller's responsibility to close ln when finished.
+// Closing ln does not affect f, and closing f does not affect ln.
+// This is similar to https://golang.org/pkg/net/#FileListener
+// but for vsock-backed files.
+func FileListener(f *os.File) (ln net.Listener, err error) {
+	fd, err := unix.Dup(int(f.Fd()))
+	if err != nil {
+		return nil, err
+	}
+
+	lfd := &sysListenFD{
+		fd: fd,
+	}
+
+	return newListener(lfd)
+}
+
 // listen is the entry point for Listen on Linux.
 func listen(cid, port uint32) (*Listener, error) {
 	lfd, err := newListenFD()
@@ -55,6 +75,41 @@ func listen(cid, port uint32) (*Listener, error) {
 	}
 
 	return listenLinux(lfd, cid, port)
+}
+
+func newListener(lfd listenFD) (l *Listener, err error) {
+	lsa, err := lfd.Getsockname()
+	if err != nil {
+		return nil, err
+	}
+
+	// Done with blocking mode setup, transition to non-blocking before the
+	// caller has a chance to start calling things concurrently that might make
+	// the locking situation tricky.
+	//
+	// Note: if any calls fail after this point, lfd.Close should be invoked
+	// for cleanup because the socket is now non-blocking.
+	if err := lfd.SetNonblocking("vsock-listen"); err != nil {
+		return nil, err
+	}
+
+	switch lsavm := lsa.(type) {
+	case *unix.SockaddrVM:
+		addr := &Addr{
+			ContextID: lsavm.CID,
+			Port:      lsavm.Port,
+		}
+		return &Listener{
+			l: &listener{
+				fd:   lfd,
+				addr: addr,
+			},
+		}, nil
+		return
+
+	default:
+		return nil, fmt.Errorf("not an AF_VSOCK file")
+	}
 }
 
 // listenLinux is the entry point for tests on Linux.
@@ -85,31 +140,5 @@ func listenLinux(lfd listenFD, cid, port uint32) (l *Listener, err error) {
 		return nil, err
 	}
 
-	lsa, err := lfd.Getsockname()
-	if err != nil {
-		return nil, err
-	}
-
-	// Done with blocking mode setup, transition to non-blocking before the
-	// caller has a chance to start calling things concurrently that might make
-	// the locking situation tricky.
-	//
-	// Note: if any calls fail after this point, lfd.Close should be invoked
-	// for cleanup because the socket is now non-blocking.
-	if err := lfd.SetNonblocking("vsock-listen"); err != nil {
-		return nil, err
-	}
-
-	lsavm := lsa.(*unix.SockaddrVM)
-	addr := &Addr{
-		ContextID: lsavm.CID,
-		Port:      lsavm.Port,
-	}
-
-	return &Listener{
-		l: &listener{
-			fd:   lfd,
-			addr: addr,
-		},
-	}, nil
+	return newListener(lfd)
 }


### PR DESCRIPTION
This is an implementation of https://golang.org/pkg/net/#FileListener
but for a vsock file.
I'm going to use this in combination with
https://github.com/coreos/go-systemd/tree/main/activation
to make use of systemd vsock support for socket activation.

Ideally go would get native vsock support in its `net` module, or has this been tried already, and deemed not possible?