### PR TITLE
Update to use net.ErrClosed

### DIFF
--- a/vsock.go
+++ b/vsock.go
@@ -1,7 +1,6 @@
 package vsock
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -403,7 +402,7 @@ func opError(op string, err error, local, remote net.Addr) error {
 		//
 		// To rectify the differences, net.TCPConn uses an error with this text
 		// from internal/poll for the backing file already being closed.
-		err = errors.New("use of closed network connection")
+		err = net.ErrClosed
 	default:
 		// Nothing to do, return this directly.
 	}


### PR DESCRIPTION
In #50 the user @dimalinux proposed updating from an error string the the `net.ErrClosed` library.  As mentioned by @dimalinux, this change keeps the error string the same, while updating the behavior of the vsock library to be similar to the standard library.  One benefit is that with this change, a user can now check for the error via 
```
errors.Is(err, net.ErrClosed)
```
instead of comparing error strings.

I only made the change in the code but I am happy to add a test for this but I was not sure where the correct place would be.  Any guidance on that would be great!

Closes: https://github.com/mdlayher/vsock/issues/50