### PR TITLE
Update CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directories:
+      - "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
+        group-by: dependency-name
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/linux-integration-test.yml
+++ b/.github/workflows/linux-integration-test.yml
@@ -3,27 +3,30 @@ name: Linux Integration Test
 on:
   push:
     branches:
-      - "*"
+      - main
   pull_request:
-    branches:
-      - "*"
+
+permissions:
+  contents: read
 
 jobs:
   build:
     strategy:
       matrix:
-        go-version: ["1.23", "1.24"]
+        go-version:
+          - "1.25"
+          - "1.26"
     runs-on: ubuntu-latest
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Load the vhost_vsock kernel module
         run: sudo modprobe vhost_vsock

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -3,27 +3,30 @@ name: Linux Test
 on:
   push:
     branches:
-      - "*"
+      - main
   pull_request:
-    branches:
-      - "*"
+
+permissions:
+  contents: read
 
 jobs:
   build:
     strategy:
       matrix:
-        go-version: ["1.23", "1.24"]
+        go-version:
+          - "1.25"
+          - "1.26"
     runs-on: ubuntu-latest
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run tests
         run: go test -v -race ./...

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -3,27 +3,29 @@ name: macOS Test
 on:
   push:
     branches:
-      - "*"
+      - main
   pull_request:
-    branches:
-      - "*"
+
+permissions:
+  contents: read
 
 jobs:
   build:
     strategy:
       matrix:
-        go-version: ["1.24"]
+        go-version:
+          - "1.26"
     runs-on: macos-latest
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run tests
         run: go test -v -race ./...

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,36 +3,32 @@ name: Static Analysis
 on:
   push:
     branches:
-      - "*"
+      - main
   pull_request:
-    branches:
-      - "*"
+
+permissions:
+  contents: read
 
 jobs:
   build:
     strategy:
       matrix:
-        go-version: ["1.24"]
+        go-version:
+          - "1.26"
     runs-on: ubuntu-latest
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@latest
-
-      - name: Print staticcheck version
-        run: staticcheck -version
-
-      - name: Run staticcheck
-        run: staticcheck ./...
-
-      - name: Run go vet
-        run: go vet ./...
+      - name: Lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          args: --verbose
+          version: v2.11.4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,21 @@
+version: "2"
+linters:
+  enable:
+    # - errorlint
+    - misspell
+    - modernize
+    - revive
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - errcheck
+        path: _test.go
+formatters:
+  exclusions:
+    generated: lax

--- a/cmd/vscp/main.go
+++ b/cmd/vscp/main.go
@@ -60,11 +60,11 @@ func main() {
 // or stdout, if no file is specified.
 func receive(target string, port uint32, timeout time.Duration, checksum bool) {
 	// Log helper functions.
-	logf := func(format string, a ...interface{}) {
+	logf := func(format string, a ...any) {
 		logf("receive: "+format, a...)
 	}
 
-	fatalf := func(format string, a ...interface{}) {
+	fatalf := func(format string, a ...any) {
 		log.Fatalf("vscp: receive: "+format, a...)
 	}
 
@@ -138,11 +138,11 @@ func receive(target string, port uint32, timeout time.Duration, checksum bool) {
 // is specified.
 func send(target string, cid, port uint32, checksum bool) {
 	// Log helper functions.
-	logf := func(format string, a ...interface{}) {
+	logf := func(format string, a ...any) {
 		logf("send: "+format, a...)
 	}
 
-	fatalf := func(format string, a ...interface{}) {
+	fatalf := func(format string, a ...any) {
 		log.Fatalf("vscp: send: "+format, a...)
 	}
 
@@ -195,7 +195,7 @@ func send(target string, cid, port uint32, checksum bool) {
 
 // logf shows verbose logging if -v is specified, or does nothing
 // if it is not.
-func logf(format string, a ...interface{}) {
+func logf(format string, a ...any) {
 	if !*flagVerbose {
 		return
 	}

--- a/conn_linux.go
+++ b/conn_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package vsock
 

--- a/fd_linux.go
+++ b/fd_linux.go
@@ -31,6 +31,6 @@ func isErrno(err error, errno int) bool {
 	}
 }
 
-func panicf(format string, a ...interface{}) {
+func panicf(format string, a ...any) {
 	panic(fmt.Sprintf(format, a...))
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mdlayher/vsock
 
-go 1.23.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/integration_linux_test.go
+++ b/integration_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package vsock_test
 
@@ -209,8 +208,8 @@ func TestIntegrationConnDialNoListener(t *testing.T) {
 	// underlying socket library, but we test it anyway to lock things in.
 	//
 	// See: https://github.com/mdlayher/vsock/issues/47.
-	const max = math.MaxUint32
-	for _, port := range []uint32{max - 2, max - 1, max} {
+	const maxUint32 = math.MaxUint32
+	for _, port := range []uint32{maxUint32 - 2, maxUint32 - 1, maxUint32} {
 		_, err := vsock.Dial(vsock.Local, port, nil)
 		if err == nil {
 			t.Fatal("dial succeeded, but should not have")
@@ -545,6 +544,6 @@ func makeLocalPipe(
 	}
 }
 
-func panicf(format string, a ...interface{}) {
+func panicf(format string, a ...any) {
 	panic(fmt.Sprintf(format, a...))
 }

--- a/listener_linux.go
+++ b/listener_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package vsock
 


### PR DESCRIPTION
* Update CI actions with SHA pinning.
* Migrate static-analysis to golangci-lint.
* Add golangci-lint config.
* Fixup various linting issues
* Bump minimum version to Go 1.25.x.